### PR TITLE
Web 2991

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,8 @@ Changelog
 ------------------
 
 - Add new Rich Text Description field
-- Print description and Detailed Description in Medialink page 
-- Print description below each medialink in collection view
+- Print Detailed Description and hide "classic" description in Medialink page
+- Print description below each medialink in collection view and can hide it thanks to ICpskinIndexViewSettings show_descriptions settings
   [cboulanger]
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Changelog
 0.2.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add new Rich Text Description field
+- Print description and Detailed Description in Medialink page 
+- Print description below each medialink in collection view
+  [cboulanger]
 
 
 0.2.6 (2018-04-06)

--- a/src/imio/media/browser/medialink_oembed_view.py
+++ b/src/imio/media/browser/medialink_oembed_view.py
@@ -10,6 +10,12 @@ class MediaLinkView(BrowserView):
       * url2embed
     """
 
+    def description(self):
+        return self.context.description
+
+    def rich_description(self):
+        return self.context.richdescription.output
+
     def embed(self):
         return utils.embed(self.context, self.request)
 

--- a/src/imio/media/browser/medialink_oembed_view.py
+++ b/src/imio/media/browser/medialink_oembed_view.py
@@ -14,7 +14,7 @@ class MediaLinkView(BrowserView):
         return self.context.description
 
     def rich_description(self):
-        return self.context.richdescription.output
+        return self.context.richdescription.output if self.context.richdescription is not None else ''
 
     def embed(self):
         return utils.embed(self.context, self.request)

--- a/src/imio/media/browser/templates/list-oembed.pt
+++ b/src/imio/media/browser/templates/list-oembed.pt
@@ -1,10 +1,11 @@
 <div class="faceted-list-oembed"
-     tal:define="realobject python:context.getObject()">
+     tal:define="batch python: context.results(b_size=25);realobject python:context.getObject();folderview context/@@folderview_view;show_descriptions python: folderview.show_descriptions(batch);">
   <div class="iframe-responsive-wrapper"
       tal:attributes="style python:view.get_style(realobject)">
       <img class="iframe-ratio"  src="data:image/gif;base64,R0lGODlhEAAJAIAAAP///wAAACH5BAEAAAAALAAAAAAQAAkAAAIKhI+py+0Po5yUFQA7"/>
       <div tal:content="structure python:view.embed(realobject)"></div>
   </div>
   <div class="oembed-title"><a href="" tal:attributes="href realobject/absolute_url" tal:content="realobject/title"/></div>
-  <div class="oembed-description"><span tal:content="realobject/description"/></div>
+  <div tal:condition="show_descriptions" class="oembed-description trololo"><span tal:content="realobject/description"/>
+  </div>
 </div>

--- a/src/imio/media/browser/templates/list-oembed.pt
+++ b/src/imio/media/browser/templates/list-oembed.pt
@@ -6,4 +6,5 @@
       <div tal:content="structure python:view.embed(realobject)"></div>
   </div>
   <div class="oembed-title"><a href="" tal:attributes="href realobject/absolute_url" tal:content="realobject/title"/></div>
+  <div class="oembed-description"><span tal:content="realobject/description"/></div>
 </div>

--- a/src/imio/media/browser/templates/medialink_oembed_view.pt
+++ b/src/imio/media/browser/templates/medialink_oembed_view.pt
@@ -8,8 +8,14 @@
 
 <metal:block metal:fill-slot="content-core">
   <div class="iframe-responsive-wrapper" tal:attributes="style view/get_style">
-      <img class="iframe-ratio"  src="data:image/gif;base64,R0lGODlhEAAJAIAAAP///wAAACH5BAEAAAAALAAAAAAQAAkAAAIKhI+py+0Po5yUFQA7"/>
+      <img class="iframe-ratio"  src="data:image/gif;base64,R0lGODlhEAAJAIAAAP///wAAACH5BAEAAAAALAAAAAAQAAkAAAIKhI+py+0Po5yUFQA7"/>      
       <div tal:content="structure view/embed"></div>
+  </div>
+  <div class="medialink-description-block">
+  <span class="medialink-description" tal:content="view/description"></span>
+  </div>
+  <div class="medialink-richdescription-block">
+  <span class="medialink-richdescription" tal:content="structure view/rich_description"></span>
   </div>
 </metal:block>
 </html>

--- a/src/imio/media/browser/templates/medialink_oembed_view.pt
+++ b/src/imio/media/browser/templates/medialink_oembed_view.pt
@@ -11,9 +11,6 @@
       <img class="iframe-ratio"  src="data:image/gif;base64,R0lGODlhEAAJAIAAAP///wAAACH5BAEAAAAALAAAAAAQAAkAAAIKhI+py+0Po5yUFQA7"/>      
       <div tal:content="structure view/embed"></div>
   </div>
-  <div class="medialink-description-block">
-  <span class="medialink-description" tal:content="view/description"></span>
-  </div>
   <div class="medialink-richdescription-block">
   <span class="medialink-richdescription" tal:content="structure view/rich_description"></span>
   </div>

--- a/src/imio/media/imio_media.py
+++ b/src/imio/media/imio_media.py
@@ -3,6 +3,7 @@ from zope.interface import implements
 from plone.supermodel import model
 from zope.schema import TextLine, Int
 from . import _
+from plone.app.textfield import RichText
 from plone.dexterity.content import Item
 
 
@@ -25,6 +26,11 @@ class IMediaLink(model.Schema):
         title=_(u'Max height'),
         description=_(u'Like "768", this value is in pixel'),
         required=False,
+    )
+
+    richdescription = RichText(
+        title=_(u'Detailed description'),
+        required=False
     )
 
 


### PR DESCRIPTION
. Add new rich description field in media content
. hide "classic" description out of media view
. print description in faceted media Oembeded and can hide description in this view thanks to ICpskinIndexViewSettings show_descriptions settings.